### PR TITLE
Fixed unexpected id argument on Video model

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -28,7 +28,7 @@ class ApiModel(object):
 
 class Image(ApiModel):
 
-    def __init__(self, url, width, height):
+    def __init__(self, url, width, height, **kwargs):
         self.url = url
         self.height = height
         self.width = width

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="python-instagram",
-      version="1.3.2.5",
+      version="1.3.2.6",
       description="Instagram API client",
       license="MIT",
       install_requires=["simplejson", "httplib2==0.9.2","six"],


### PR DESCRIPTION
Lastly we were getting several TypeErrors due to payload from Instagram responses now include "id" field and we are not expecting it in Video and Image class models initialization.

This is the traceback:
```
TypeError: __init__() got an unexpected keyword argument 'id'
  File "instagram/bind.py", line 223, in _call
    return method.execute()
  File "instagram/bind.py", line 215, in execute
    content, next = self._do_api_request(url, method, body, headers)
  File "instagram/bind.py", line 184, in _do_api_request
    api_responses = self.root_class.object_from_dictionary(data)
  File "instagram/models.py", line 87, in object_from_dictionary
    new_media.videos[version] = Video.object_from_dictionary(version_info)
  File "instagram/models.py", line 13, in object_from_dictionary
    return cls(**entry_str_dict)
```

Please merge my pull request to solve such error. Thanks in advance.
